### PR TITLE
Revert "Move Logger interface from usecases to interfaces"

### DIFF
--- a/app/infrastructure/env.go
+++ b/app/infrastructure/env.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmf-san/go-clean-architecture-web-application-boilerplate/app/interfaces"
+	"github.com/bmf-san/go-clean-architecture-web-application-boilerplate/app/usecases"
 )
 
 // Load is load configs from a env file.
-func Load(logger interfaces.Logger) {
+func Load(logger usecases.Logger) {
 	filePath := ".env"
 
 	f, err := os.Open(filePath)

--- a/app/infrastructure/logger.go
+++ b/app/infrastructure/logger.go
@@ -4,13 +4,15 @@ import (
 	"io"
 	"log"
 	"os"
+
+	"github.com/bmf-san/go-clean-architecture-web-application-boilerplate/app/usecases"
 )
 
 // A Logger belong to the infrastructure layer.
 type Logger struct{}
 
 // NewLogger return a Logger.
-func NewLogger() *Logger {
+func NewLogger() usecases.Logger {
 	return &Logger{}
 }
 

--- a/app/infrastructure/router.go
+++ b/app/infrastructure/router.go
@@ -5,11 +5,12 @@ import (
 	"os"
 
 	"github.com/bmf-san/go-clean-architecture-web-application-boilerplate/app/interfaces"
+	"github.com/bmf-san/go-clean-architecture-web-application-boilerplate/app/usecases"
 	"github.com/go-chi/chi"
 )
 
 // Dispatch is handle routing
-func Dispatch(logger interfaces.Logger, sqlHandler interfaces.SQLHandler) {
+func Dispatch(logger usecases.Logger, sqlHandler interfaces.SQLHandler) {
 	userController := interfaces.NewUserController(sqlHandler, logger)
 	postController := interfaces.NewPostController(sqlHandler, logger)
 

--- a/app/interfaces/post_controller.go
+++ b/app/interfaces/post_controller.go
@@ -12,11 +12,11 @@ import (
 // A PostController belong to the interface layer.
 type PostController struct {
 	PostInteractor usecases.PostInteractor
-	Logger         Logger
+	Logger         usecases.Logger
 }
 
 // NewPostController returns the resource of Posts.
-func NewPostController(sqlHandler SQLHandler, logger Logger) *PostController {
+func NewPostController(sqlHandler SQLHandler, logger usecases.Logger) *PostController {
 	return &PostController{
 		PostInteractor: usecases.PostInteractor{
 			PostRepository: &PostRepository{

--- a/app/interfaces/user_controller.go
+++ b/app/interfaces/user_controller.go
@@ -11,11 +11,11 @@ import (
 // A UserController belong to the interface layer.
 type UserController struct {
 	UserInteractor usecases.UserInteractor
-	Logger         Logger
+	Logger         usecases.Logger
 }
 
 // NewUserController returns the resource of users.
-func NewUserController(sqlHandler SQLHandler, logger Logger) *UserController {
+func NewUserController(sqlHandler SQLHandler, logger usecases.Logger) *UserController {
 	return &UserController{
 		UserInteractor: usecases.UserInteractor{
 			UserRepository: &UserRepository{

--- a/app/usecases/logger.go
+++ b/app/usecases/logger.go
@@ -1,4 +1,4 @@
-package interfaces
+package usecases
 
 // A Logger belong to the usecases layer.
 type Logger interface {


### PR DESCRIPTION
Reverts bmf-san/go-clean-architecture-web-application-boilerplate#12

I remembered that the logger interface was defined in the usercase layer to reverse the dependencies.