### PR TITLE
Fix: Incomplete value if it contains the = symbol

### DIFF
--- a/app/infrastructure/env.go
+++ b/app/infrastructure/env.go
@@ -3,6 +3,7 @@ package infrastructure
 import (
 	"bufio"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/bmf-san/go-clean-architecture-web-application-boilerplate/app/usecases"
@@ -28,7 +29,12 @@ func Load(logger usecases.Logger) {
 	}
 
 	for _, l := range lines {
-		pair := strings.Split(l, "=")
-		os.Setenv(pair[0], pair[1])
+		pair := regexp.MustCompile(`=`).Split(l, 2)
+
+		if len(pair) > 1 {
+			os.Setenv(strings.TrimSpace(pair[0]), strings.TrimSpace(pair[1]))
+		} else {
+			logger.LogError(".env file. Wrong format for " + pair[0])
+		}
 	}
 }


### PR DESCRIPTION
# Overview
Reading the <code>.env</code> file:
if the value contains the = symbol then delete it.
# Changes
Capture only the first = symbol.
All leading and trailing white space removed.

## Example

```env
DB_PASSWORD   =   w1G43+R/c4v8= 
```

### Value obtained:
```shell
   w1G43+R/c4v8 
```
### Expected value:
```shell
w1G43+R/c4v8=
```
